### PR TITLE
Use Argon2id for key derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 # cotp - command line totp authenticator
+[[![Actions Status](https://github.com/replydev/cotp/workflows/Rust/badge.svg)]("https://github.com/replydev/cotp/actions")
 
 I believe that security is of paramount importance, especially in this digital world. I created cotp because I needed a minimalist, secure, desktop accessible software to manage my two-factor authentication codes.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You will find the compiled binary in **target/release** folder
 ## Planned features
 
  - [x] Reduce binary size and improve compilation speed by removing useless dependencies.
- - [ ] Use argon2id13 for key derivation
+ - [x] Use argon2id13 for key derivation
  - [ ] Backup compatibility with:
 	 - [x] Aegis
 	 - [x] andOTP

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # cotp - command line totp authenticator
-[[![Actions Status](https://github.com/replydev/cotp/workflows/Rust/badge.svg)]("https://github.com/replydev/cotp/actions")
+[![Actions Status](https://github.com/replydev/cotp/workflows/Rust/badge.svg)]("https://github.com/replydev/cotp/actions")
 
 I believe that security is of paramount importance, especially in this digital world. I created cotp because I needed a minimalist, secure, desktop accessible software to manage my two-factor authentication codes.
 

--- a/src/argument_functions.rs
+++ b/src/argument_functions.rs
@@ -7,7 +7,7 @@ pub fn help(){
     println!("-a,--add <secret> <issuer> <label>       | Add a new OTP code");
     println!("-r,--remove <secret> <issuer> <label>    | Remove an OTP code");
     println!("-e,--edit <id> <secret> <issuer> <label> | Edit an OTP code");
-    println!("-i,--import <appname> <filename>         | Import a backup from a given application");
+    println!("-i,--import <appname> <path>             | Import a backup from a given application");
     println!("-ex,--export                             | Export the entire database in a plaintext json format");
     println!("-j,--json                                | Print results in json format");
     println!("-h,--help                                | Print this help");
@@ -38,7 +38,11 @@ pub fn import(args: Vec<String>){
         println!("Successfully imported database");
     }
     else{
-        println!("Invalid arguments, type cotp --import <backup_format> <path>");
+        println!("Invalid arguments, type cotp --import <appname> <path>");
+        println!("cotp can import backup from:");
+        println!("\"cotp\"");
+        println!("\"aegis\"");
+        println!("\"andotp\"");
     }
 }
 

--- a/src/argument_functions.rs
+++ b/src/argument_functions.rs
@@ -7,7 +7,7 @@ pub fn help(){
     println!("-a,--add <secret> <issuer> <label>       | Add a new OTP code");
     println!("-r,--remove <secret> <issuer> <label>    | Remove an OTP code");
     println!("-e,--edit <id> <secret> <issuer> <label> | Edit an OTP code");
-    println!("-i,--import aegis,andotp <filename>      | Import a backup from a given application");
+    println!("-i,--import <appname> <filename>         | Import a backup from a given application");
     println!("-ex,--export                             | Export the entire database in a plaintext json format");
     println!("-j,--json                                | Print results in json format");
     println!("-h,--help                                | Print this help");
@@ -19,7 +19,7 @@ pub fn import(args: Vec<String>){
         let elements: Vec<database_loader::OTPElement>;
 
         match &args[2][..]{
-            "andotp" => result = importers::and_otp::import(&args[3]),
+            "cotp" | "andotp" => result = importers::and_otp::import(&args[3]),
             "aegis" => result = importers::aegis::import(&args[3]),
             _=> {
                 println!("Invalid argument: {}", &args[2]);

--- a/src/database_loader.rs
+++ b/src/database_loader.rs
@@ -67,9 +67,9 @@ impl OTPElement {
 }
 
 pub fn read_from_file() -> Result<Vec<OTPElement>,String>{
-    let mut encrypted_contents = read_to_string(&get_db_path()).unwrap();
+    let encrypted_contents = read_to_string(&get_db_path()).unwrap();
     //rust close files at the end of the function
-    let contents = cryptograpy::decrypt_string(&mut encrypted_contents, &cryptograpy::prompt_for_passwords("Password: "));
+    let contents = cryptograpy::decrypt_string(&encrypted_contents, &cryptograpy::prompt_for_passwords("Password: "));
     match contents {
         Ok(contents) => {
             let vector: Vec<OTPElement> = serde_json::from_str(&contents).unwrap();
@@ -172,8 +172,8 @@ pub fn export_database() -> Result<String, String> {
     let mut exported_path = utils::get_home_folder().to_str().unwrap().to_string();
     exported_path.push_str("/exported.cotp");
     let mut file = File::create(&exported_path).expect("Cannot create file");
-    let mut encrypted_contents = read_to_string(&get_db_path()).unwrap();
-    let contents = cryptograpy::decrypt_string(&mut encrypted_contents, &cryptograpy::prompt_for_passwords("Password: "));
+    let encrypted_contents = read_to_string(&get_db_path()).unwrap();
+    let contents = cryptograpy::decrypt_string(&encrypted_contents, &cryptograpy::prompt_for_passwords("Password: "));
     match contents {
         Ok(contents) => {
             file.write_all(contents.as_bytes()).expect("Failed to write contents");
@@ -191,7 +191,7 @@ pub fn overwrite_database(elements: Vec<OTPElement>){
 }
 
 pub fn overwrite_database_json(json: &str){
-    let encrypted = cryptograpy::encrypt_string(&mut json.to_string(), &cryptograpy::prompt_for_passwords("Insert password for database encryption: "));
+    let encrypted = cryptograpy::encrypt_string(json.to_string(), &cryptograpy::prompt_for_passwords("Insert password for database encryption: "));
     utils::write_to_file(&encrypted, &mut File::create(utils::get_db_path()).expect("Failed to open file"));
 }
 


### PR DESCRIPTION
 - These commits make cotp to use argon2id for key derivation.
 - Due to sodiumoxide limitation we can only generate a 128 bit salt, but that's enough.
 - I made also other commits that gives minor changes.
 - It's required to export your cotp data using -ex argument, and re-import using this new version.