### PR TITLE
Add seach subcommand to display OTP codes for matching db entries

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -11,6 +11,7 @@ pub fn args_parser() -> bool {
         Some(("info",info_matches)) => argument_functions::info(info_matches),
         Some(("export",export_matches)) => argument_functions::export(export_matches),
         Some(("passwd",_)) => argument_functions::change_password(),
+        Some(("search",search_matches)) => argument_functions::search(search_matches),
         _ => return true,
     }
     false
@@ -263,6 +264,27 @@ fn get_matches() -> ArgMatches{
                         .help("OTP code index")
                         .takes_value(true)
                         .required(true),
+                ),
+        )
+        .subcommand(
+            App::new("search")
+                .about("Show OTP code for matching database entries")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .arg(
+                    Arg::new("issuer")
+                        .short('i')
+                        .long("issuer")
+                        .help("Search database by issuer")
+                        .takes_value(true)
+                        .required_unless_present("label"),
+                )
+                .arg(
+                    Arg::new("label")
+                        .short('l')
+                        .long("label")
+                        .help("Search database by label")
+                        .takes_value(true)
+                        .required_unless_present("issuer"),
                 ),
         )
         .subcommand(

--- a/src/argument_functions.rs
+++ b/src/argument_functions.rs
@@ -118,6 +118,30 @@ pub fn info(matches: &ArgMatches) {
     }
 }
 
+pub fn search(matches: &ArgMatches) {
+    let result: Result<(), String>;
+    if matches.is_present("issuer") && matches.is_present("label") {
+        let issuer = matches.value_of_t_or_exit("issuer");
+        let label = matches.value_of_t_or_exit("label");
+        result = otp_helper::print_elements_matching_issuer_and_label(issuer, label);
+    }
+    else if matches.is_present("issuer") {
+        let issuer = matches.value_of_t_or_exit("issuer");
+        result = otp_helper::print_elements_matching_issuer(issuer);
+    }
+    else if matches.is_present("label") {
+        let label = matches.value_of_t_or_exit("label");
+        result = otp_helper::print_elements_matching_label(label);
+    }
+    else {
+        result = Ok(());
+    }
+    match result {
+        Ok(()) => {}
+        Err(e) => eprintln!("An error occurred: {}", e),
+    }
+}
+
 pub fn change_password() {
     let mut old_password = cryptography::prompt_for_passwords("Old password: ", 8, false);
     let decrypted_text = database_management::read_decrypted_text(&old_password);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,12 +75,15 @@ pub fn check_elements(id: usize, elements: &[OTPElement]) -> Result<(), String> 
     Ok(())
 }
 
-pub fn percentage() -> u16 {
+pub fn millis_before_next_step() -> u64 {
     let now = SystemTime::now();
     let since_the_epoch = now.duration_since(UNIX_EPOCH).unwrap();
     let in_ms = since_the_epoch.as_secs() * 1000 + since_the_epoch.subsec_nanos() as u64 / 1000000;
-    let step = in_ms % 30000;
-    (step * 100 / 30000) as u16
+    in_ms % 30000
+}
+
+pub fn percentage() -> u16 {
+    (millis_before_next_step() * 100 / 30000) as u16
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hello!

The ability to have the TUI open when I need to login to a service several times or several different services is handy, but I often only need a single code (or multiple codes for the same service under different labels), so here's a shot at adding a search subcommand. This lets you search the database for entries matching either the issuer field or the label field or both. For matching entries an OTP code is generated and then displayed along with the issuer and label.

Generated help:

```
cotp-search 
Show OTP code for matching database entries

USAGE:
    cotp search [OPTIONS]

OPTIONS:
    -h, --help               Print help information
    -i, --issuer <issuer>    Search database by issuer
    -l, --label <label>      Search database by label
```

Example output:

```
cotp search -i SomeService -l foo@foo.foo
Password: 

Issuer: SomeService
Label: foo@foo.foo
OTP Code: 123456 (12 seconds remaining)
```

I am still fairly new to rust so if I got anything wrong or not following best practices I am happy to fix it.