### PR TITLE
Support OSC52 copying (and Wayland)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2f548212db51db2dba038e6e86c98a5d4a8ab0767ab230673a28be89a45b87"
 dependencies = [
+ "base64",
  "copypasta",
  "libc",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rpassword = "6.0.1"
 data-encoding = "2.3.2"
 crossterm = "0.23.2"
 tui = "0.18.0"
-copypasta-ext = "0.3.7"
+copypasta-ext = { version="0.3.7", features = ["osc52"] }
 zeroize = "1.4.3"
 clap = "3.1.18"
 hmac = "0.12.1"


### PR DESCRIPTION
What do you think about this approach? It tries Wayand, then X11, and finally OSC52. Personally that works really well for me, as I mainly run on a remote VPS without a graphics environment.

Also, I'm still new to Rust, and tried a long to refactor the blocks in `copy_to_clipboard_decide_method()` but got lost in the types. There seems to be a generic `ClipboardProvider` type but I just couldn't figure out how to implement it. I'd love to know if you can see a way to DRY it.