### PR TITLE
Fix typo: `algoritmh` -> `algorithm`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -65,7 +65,7 @@ pub fn get_matches() -> ArgMatches {
                 .arg(
                     Arg::new("algorithm")
                         .short('a')
-                        .long("algoritmh")
+                        .long("algorithm")
                         .help("OTP Code algorithm")
                         .num_args(1)
                         .required(false)
@@ -142,7 +142,7 @@ pub fn get_matches() -> ArgMatches {
                 .arg(
                     Arg::new("algorithm")
                         .short('a')
-                        .long("algoritmh")
+                        .long("algorithm")
                         .help("OTP Code algorithm")
                         .num_args(1)
                         .required_unless_present_any(["label", "issuer", "digits", "counter"])

--- a/src/otp/algorithms/yandex_otp_maker.rs
+++ b/src/otp/algorithms/yandex_otp_maker.rs
@@ -27,13 +27,13 @@ pub fn yandex(
     pin: &str,
     period: u64,
     digits: usize,
-    algoritmh: OTPAlgorithm,
+    algorithm: OTPAlgorithm,
 ) -> Result<String, String> {
     let seconds = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    match algoritmh {
+    match algorithm {
         OTPAlgorithm::Sha256 => {
             calculate_yandex_code::<Sha256>(secret, pin, period, digits, seconds)
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18603393/206288198-891d0bf9-1a5a-4eb2-a9c4-211cd296dfb1.png)