### PR TITLE
Fix double input on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cotp"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "aes-gcm",
  "base64 0.21.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cotp"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["replydev <commoncargo@tutanota.com>"]
 edition = "2021"
 description = "Trustworthy, encrypted, command-line TOTP/HOTP authenticator app with import functionality."


### PR DESCRIPTION
This PR fixes double input on Windows caused by a bug in the crossterm library.
Please check https://github.com/crossterm-rs/crossterm/issues/752
                            