### PR TITLE
Refactor Argument Parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,17 +34,28 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
-      - name: Install dependencies
-        run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-                sudo apt update && sudo apt install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
-          fi
-        shell: bash
+      - name: Install cross for arm64 compilation
+        if: matrix.build == 'aarch64-linux'
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
-      - name: Run cargo test
+      - name: Install Dependencies for Linux x86_64
+        if: matrix.build == 'x86_64-linux'
+        run: sudo apt update && sudo apt install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
+
+      - name: Run tests (arm64)
+        if: matrix.build == 'aarch64-linux'
+        run: cross test --locked --target ${{ matrix.target }}
+
+      - name: Build debug binary (arm64)
+        if: matrix.build == 'aarch64-linux'
+        run: cross build --locked --target ${{ matrix.target }}
+
+      - name: Run tests (x86_64)
+        if: matrix.build != 'aarch64-linux'
         run: cargo test
 
-      - name: Run cargo build
+      - name: Build debug binary (x86_64)
+        if: matrix.build != 'aarch64-linux'
         run: cargo build
 
       - uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,5 +49,5 @@ jobs:
 
       - uses: actions/upload-artifact@v3.1.2
         with:
-          name: bins-${{ matrix.os }}
+          name: bins-${{ matrix.build }}
           path: target/debug/cotp*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,20 @@ jobs:
     name: Build debug artifacts
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-win-gnu]
+        include:
+          - build: x86_64-linux
+            os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+          - build: aarch64-linux
+            os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+          - build: x86_64-macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: x86_64-win-gnu
+            os: windows-2019
+            target: x86_64-pc-windows-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -18,6 +31,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.target }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ matrix.target }}
+          target: ${{ matrix.target }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,4 +61,9 @@ jobs:
       - uses: actions/upload-artifact@v3.1.2
         with:
           name: bins-${{ matrix.build }}
-          path: target/debug/cotp*
+          # Two paths, the first for x86_64 jobs, the second for aarch64.
+          # No need to dispatch, if the path is not found we continue normally
+          path: |
+            target/debug/cotp*
+            target/aarch64-unknown-linux-gnu/debug/cotp*
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
-        build: [x86_64-linux, aarch64-linux, x86_64-win-gnu] #, x86_64-windows, win32-msvc
+        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-win-gnu] #, x86_64-windows, win32-msvc
         include:
           - build: x86_64-linux
             os: ubuntu-20.04
@@ -24,6 +24,9 @@ jobs:
           - build: aarch64-linux
             os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
+          - build: x86_64-macos
+            os: macos-latest
+            target: x86_64-apple-darwin
           - build: x86_64-win-gnu
             os: windows-2019
             target: x86_64-pc-windows-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,6 @@ jobs:
         if: matrix.build == 'x86_64-linux'
         run: sudo apt update && sudo apt install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev
 
-      - name: Build Docker image for aarch64 compilation
-        if: matrix.build == 'aarch64-linux'
-        run: docker build -t cotp_build_aarch64:latest .
-
       - name: Build release binary (arm64)
         if: matrix.build == 'aarch64-linux'
         run: cross build --release --locked --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
@@ -254,6 +256,18 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -546,6 +560,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ crossterm = "0.26.1"
 tui = "0.19.0"
 copypasta-ext = "0.4.4"
 zeroize = "1.6.0"     
-clap = "4.3.0"
+clap = { version = "4.3.0", features = ["derive"] }
 hmac = "0.12.1"
 sha-1 = "0.10.1"
 sha2 = "0.10.6"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,13 +1,197 @@
-use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
+use std::path::PathBuf;
 
-use crate::{argument_functions, otp::otp_element::OTPDatabase};
+use clap::{Args, Parser, Subcommand};
+
+use crate::{
+    argument_functions,
+    otp::{otp_algorithm::OTPAlgorithm, otp_element::OTPDatabase, otp_type::OTPType},
+};
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct CotpArgs {
+    #[command(subcommand)]
+    command: Option<CotpSubcommands>,
+}
+
+#[derive(Subcommand)]
+enum CotpSubcommands {
+    /// Add new OTP code
+    Add(AddArgs),
+    /// Edit an existing OTP Code
+    Edit(EditArgs),
+    /// Remove an OTP Code
+    Remove(RemoveArgs),
+    /// Import codes from other apps
+    Import(ImportArgs),
+    /// Export cotp database
+    Export(ExportArgs),
+    /// Change database password
+    Passwd,
+}
+
+#[derive(Args)]
+pub struct AddArgs {
+    /// Add OTP code via an OTP URI
+    #[arg(short = 'u', long = "otpuri", required_unless_present = "issuer")]
+    pub otp_uri: bool,
+
+    /// Specify the OTP code type
+    #[arg(short = 't', long = "type", default_value_t = OTPType::Totp)]
+    pub otp_type: OTPType,
+
+    /// Code issuer
+    #[arg(short, long, required_unless_present = "otp_uri")]
+    pub issuer: String,
+
+    /// Code label
+    #[arg(short, long, default_value = "")]
+    pub label: String,
+
+    /// OTP Algorithm
+    #[arg(short, long, value_enum, default_value_t = OTPAlgorithm::Sha1)]
+    pub mode: OTPAlgorithm,
+
+    /// Code digits
+    #[arg(
+        short,
+        long,
+        default_value_t = 6,
+        default_value_if("type", "STEAM", "5")
+    )]
+    pub digits: u8,
+
+    /// Code period
+    #[arg(short, long, default_value_t = 30)]
+    pub period: u64,
+
+    /// HOTP counter
+    #[arg(short, long, required_if_eq("type", "HOTP"))]
+    pub counter: Option<u64>,
+
+    /// Yandex / MOTP pin
+    #[arg(
+        short,
+        long,
+        required_if_eq("type", "YANDEX"),
+        required_if_eq("type", "MOTP")
+    )]
+    pub pin: Option<String>,
+}
+
+#[derive(Args)]
+pub struct EditArgs {
+    /// Code Index
+    #[arg(short, long, required = true)]
+    index: u64,
+
+    /// Code issuer
+    #[arg(short = 's', long)]
+    issuer: Option<String>,
+
+    /// Code label
+    #[arg(short, long)]
+    label: Option<String>,
+
+    /// OTP algorithm
+    #[arg(short, long, value_enum)]
+    mode: Option<OTPAlgorithm>,
+
+    /// Code digits
+    #[arg(short, long)]
+    digits: Option<u8>,
+
+    /// Code period
+    #[arg(short, long)]
+    period: Option<u64>,
+
+    /// HOTP counter
+    #[arg(short, long)]
+    counter: Option<u64>,
+
+    /// Yandex / MOTP pin
+    #[arg(short, long)]
+    pin: Option<String>,
+
+    /// Change code secret
+    #[arg(short = 'k', long = "change-secret")]
+    change_secret: bool,
+}
+
+#[derive(Args)]
+pub struct RemoveArgs {
+    /// Code Index
+    #[arg(short, long, required = true)]
+    index: u64,
+}
+
+#[derive(Args)]
+pub struct ImportArgs {
+    #[command(flatten)]
+    backup_type: BackupType,
+
+    /// Backup file path
+    #[arg(short, long, required = true)]
+    path: PathBuf,
+}
+
+#[derive(Args)]
+pub struct ExportArgs {
+    /// Export file path
+    #[arg(short, long, default_value = ".")]
+    path: PathBuf,
+}
+
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct BackupType {
+    /// Import from cotp backup
+    #[arg(short, long)]
+    cotp: bool,
+
+    /// Import from andOTP backup
+    #[arg(short = 'e', long)]
+    andotp: bool,
+
+    /// Import from Aegis backup
+    #[arg(short, long)]
+    aegis: bool,
+
+    /// Import from Aegis Encrypted backup
+    #[arg(short = 'k', long = "aegis-encrypted")]
+    aegis_encrypted: bool,
+
+    /// Import from FreeOTP+ backup
+    #[arg(short, long = "freeotp-plus")]
+    freeotp_plus: bool,
+
+    /// Import from FreeOTP backup
+    #[arg(short = 'r', long)]
+    freeotp: bool,
+
+    /// Import from Google Authenticator backup
+    #[arg(short, long = "google-authenticator")]
+    google_authenticator: bool,
+
+    /// Import from Authy backup
+    #[arg(short = 't', long)]
+    authy: bool,
+
+    /// Import from Authy Database exported following this guide https://gist.github.com/gboudreau/94bb0c11a6209c82418d01a59d958c93
+    #[arg(short = 'u', long = "authy-exported")]
+    authy_exported: bool,
+
+    /// Import from Microsoft Authenticator
+    #[arg(short = 'm', long = "microsoft-authenticator")]
+    microsoft_authenticator: bool,
+}
 
 pub fn args_parser(
-    matches: ArgMatches,
+    matches: CotpArgs,
     database: &mut OTPDatabase,
 ) -> Option<Result<String, String>> {
-    match matches.subcommand() {
-        Some(("add", add_matches)) => Some(argument_functions::add(add_matches, database)),
+    match matches.command {
+        Some(CotpSubcommands::Add(args)) => Some(argument_functions::add(args, database)),
         Some(("edit", edit_matches)) => Some(argument_functions::edit(edit_matches, database)),
         Some(("import", import_matches)) => {
             Some(argument_functions::import(import_matches, database))
@@ -21,513 +205,8 @@ pub fn args_parser(
     }
 }
 
-pub fn get_matches() -> ArgMatches {
-    Command::new(env!("CARGO_PKG_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .author(
-            env!("CARGO_PKG_AUTHORS")
-                .split(',')
-                .next()
-                .unwrap_or("replydev <commoncargo@tutanota.com>"),
-        )
-        .about(env!("CARGO_PKG_DESCRIPTION"))
-        .subcommand(
-            Command::new("add")
-                .about("Add a new OTP Code")
-                .arg_required_else_help(true)
-                .arg(
-                    Arg::new("otp_uri")
-                        .short('u')
-                        .long("otpuri")
-                        .help("Add OTP code via an OTP URI")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present("issuer")
-                )
-                .arg(
-                    Arg::new("type")
-                        .short('t')
-                        .long("type")
-                        .help("Specify the OTP code type")
-                        .num_args(1)
-                        .value_parser(["TOTP", "HOTP", "STEAM", "YANDEX", "MOTP"])
-                        .default_value("TOTP"),
-                )
-                .arg(
-                    Arg::new("issuer")
-                        .short('i')
-                        .long("issuer")
-                        .help("OTP Code issuer")
-                        .num_args(1)
-                        .required_unless_present("otp_uri"),
-                )
-                .arg(
-                    Arg::new("label")
-                        .short('l')
-                        .long("label")
-                        .help("OTP Code label")
-                        .num_args(1)
-                        .required(false)
-                        .default_value(""),
-                )
-                .arg(
-                    Arg::new("algorithm")
-                        .short('a')
-                        .long("algorithm")
-                        .help("OTP Code algorithm")
-                        .num_args(1)
-                        .required(false)
-                        .value_parser(["SHA1", "SHA256", "SHA512"])
-                        .default_value("SHA1"),
-                )
-                .arg(
-                    Arg::new("digits")
-                        .short('d')
-                        .long("digits")
-                        .help("OTP Code digits")
-                        .num_args(1)
-                        .required(false)
-                        .value_parser(value_parser!(u64))
-                        .default_value_if("type", "STEAM", "5")
-                        .default_value("6"),
-                )
-                .arg(
-                    Arg::new("period")
-                        .short('e')
-                        .long("period")
-                        .help("OTP Code period")
-                        .num_args(1)
-                        .required(false)
-                        .value_parser(value_parser!(u64))
-                        .default_value("30"),
-                )
-                .arg(
-                    Arg::new("counter")
-                        .short('c')
-                        .long("counter")
-                        .help("HOTP code counter")
-                        .required_if_eq("type", "HOTP")
-                        .num_args(1)
-                        .value_parser(value_parser!(u64)),
-                ).arg(
-                Arg::new("pin")
-                    .short('p')
-                    .long("pin")
-                    .help("Code pin (for Yandex and MOTP)")
-                    .required_if_eq("type", "YANDEX")
-                    .required_if_eq("type", "MOTP")
-                    .num_args(1),
-            ),
-        )
-        .subcommand(
-            Command::new("edit")
-                .about("Edit an OTP code")
-                .arg_required_else_help(true)
-                .arg(
-                    Arg::new("index")
-                        .short('i')
-                        .long("index")
-                        .help("OTP Code index")
-                        .num_args(1)
-                        .value_parser(value_parser!(usize))
-                        .required(true),
-                )
-                .arg(
-                    Arg::new("issuer")
-                        .short('s')
-                        .long("issuer")
-                        .help("OTP Code issuer")
-                        .num_args(1)
-                        .required_unless_present_any(["label", "algorithm", "digits", "counter", "pin", "change-secret"]),
-                )
-                .arg(
-                    Arg::new("label")
-                        .short('l')
-                        .long("label")
-                        .help("OTP Code label")
-                        .num_args(1)
-                        .required_unless_present_any(["issuer", "algorithm", "digits", "counter", "pin", "change-secret"]),
-                )
-                .arg(
-                    Arg::new("algorithm")
-                        .short('a')
-                        .long("algorithm")
-                        .help("OTP Code algorithm")
-                        .num_args(1)
-                        .required_unless_present_any(["label", "issuer", "digits", "counter", "pin", "change-secret"])
-                        .value_parser(["SHA1", "SHA256", "SHA512"]),
-                )
-                .arg(
-                    Arg::new("digits")
-                        .short('d')
-                        .long("digits")
-                        .help("OTP Code digits")
-                        .num_args(1)
-                        .value_parser(value_parser!(u64))
-                        .required_unless_present_any(["label", "algorithm", "issuer", "counter", "pin", "change-secret"]),
-                )
-                .arg(
-                    Arg::new("period")
-                        .short('e')
-                        .long("period")
-                        .help("OTP Code period")
-                        .num_args(1)
-                        .value_parser(value_parser!(u64))
-                        .required_unless_present_any(["label", "algorithm", "issuer", "counter", "pin", "change-secret"]),
-                )
-                .arg(
-                    Arg::new("counter")
-                        .short('c')
-                        .long("counter")
-                        .help("HOTP code counter (only for HOTP codes)")
-                        .num_args(1)
-                        .value_parser(value_parser!(u64))
-                        .required_unless_present_any(["label", "algorithm", "issuer", "digits", "pin", "change-secret"]),
-                )
-                .arg(
-                    Arg::new("pin")
-                        .short('p')
-                        .long("pin")
-                        .help("Code pin (for Yandex and MOTP)")
-                        .num_args(1)
-                        .required_unless_present_any(["label", "algorithm", "issuer", "digits", "counter", "change-secret"]),
-                )
-                .arg(
-                    Arg::new("change-secret")
-                        .short('k')
-                        .long("change-secret")
-                        .help("Change the OTP code secret")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any(["label", "algorithm", "issuer", "digits", "counter", "pin"]),
-                ),
-        )
-        .subcommand(
-            Command::new("remove")
-                .about("Remove an OTP code")
-                .arg_required_else_help(true)
-                .arg(
-                    Arg::new("index")
-                        .short('i')
-                        .long("index")
-                        .help("OTP code index")
-                        .num_args(1..)
-                        .value_parser(value_parser!(u64))
-                        .required(true)
-                ),
-        )
-        .subcommand(
-            Command::new("import")
-                .about("Import from backups")
-                .arg_required_else_help(true)
-                .arg(
-                    Arg::new("cotp")
-                        .short('c')
-                        .long("cotp")
-                        .help("Import from cotp exported database")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ])
-                        .conflicts_with_all([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ]),
-                )
-                .arg(
-                    Arg::new("andotp")
-                        .short('e')
-                        .long("andotp")
-                        .help("Import from andOTP backup")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "cotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ])
-                        .conflicts_with_all([
-                            "cotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ]),
-                )
-                .arg(
-                    Arg::new("aegis")
-                        .short('a')
-                        .long("aegis")
-                        .help("Import from Aegis backup")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "andotp",
-                            "cotp",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ])
-                        .conflicts_with_all([
-                            "andotp",
-                            "cotp",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ]),
-                )
-                .arg(
-                    Arg::new("aegis-encrypted")
-                        .short('k')
-                        .long("aegis-encrypted")
-                        .help("Import from Aegis encrypted backup")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "andotp",
-                            "cotp",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis",
-                        ])
-                        .conflicts_with_all([
-                            "andotp",
-                            "cotp",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis",
-                        ]),
-                )
-                .arg(
-                    Arg::new("freeotp-plus")
-                        .short('f')
-                        .long("freeotp-plus")
-                        .help("Import from FreeOTP+ backup")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "andotp",
-                            "aegis",
-                            "cotp",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ])
-                        .conflicts_with_all([
-                            "andotp",
-                            "aegis",
-                            "cotp",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ]),
-                )
-                .arg(
-                    Arg::new("freeotp")
-                        .short('r')
-                        .long("freeotp")
-                        .help("Import from FreeOTP converted database")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "cotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ])
-                        .conflicts_with_all([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "cotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ]),
-                )
-                .arg(
-                    Arg::new("google-authenticator")
-                        .short('g')
-                        .long("google-authenticator")
-                        .help("Import from Google Authenticator converted database")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "cotp",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ])
-                        .conflicts_with_all([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "cotp",
-                            "authy",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ]),
-                )
-                .arg(
-                    Arg::new("authy")
-                        .short('t')
-                        .long("authy")
-                        .help("Import from Authy converted database")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "cotp",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ])
-                        .conflicts_with_all([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "cotp",
-                            "authy-exported",
-                            "microsoft-authenticator",
-                            "aegis-encrypted",
-                        ]),
-                )
-                .arg(
-                    Arg::new("microsoft-authenticator")
-                        .short('m')
-                        .long("microsoft-authenticator")
-                        .help("Import from Microsoft Authenticator converted database")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "cotp",
-                            "aegis-encrypted",
-                        ])
-                        .conflicts_with_all([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "authy-exported",
-                            "cotp",
-                            "aegis-encrypted",
-                        ]),
-                )
-                .arg(
-                    Arg::new("authy-exported")
-                        .short('u')
-                        .long("authy-exported")
-                        .help("Import from Authy Database exported following https://gist.github.com/gboudreau/94bb0c11a6209c82418d01a59d958c93")
-                        .action(ArgAction::SetTrue)
-                        .required_unless_present_any([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "microsoft-authenticator",
-                            "cotp",
-                            "aegis-encrypted",
-                        ])
-                        .conflicts_with_all([
-                            "andotp",
-                            "aegis",
-                            "freeotp-plus",
-                            "freeotp",
-                            "google-authenticator",
-                            "authy",
-                            "microsoft-authenticator",
-                            "cotp",
-                            "aegis-encrypted",
-                        ]),
-                )
-                .arg(
-                    Arg::new("path")
-                        .short('p')
-                        .long("path")
-                        .help("Backup path")
-                        .num_args(1)
-                        .required(true),
-                ),
-        )
-        .subcommand(
-            Command::new("export").about("Export your database").arg(
-                Arg::new("path")
-                    .short('p')
-                    .long("path")
-                    .help("Export file path")
-                    .num_args(1)
-                    .required(false)
-                    .default_value("."),
-            ),
-        )
-        .subcommand(Command::new("passwd").about("Change your database password"))
-        .get_matches()
+#[test]
+fn verify_cli() {
+    use clap::CommandFactory;
+    CotpArgs::command().debug_assert()
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -93,7 +93,7 @@ pub struct EditArgs {
 
     /// OTP algorithm
     #[arg(short, long, value_enum)]
-    pub mode: Option<OTPAlgorithm>,
+    pub algorithm: Option<OTPAlgorithm>,
 
     /// Code digits
     #[arg(short, long)]

--- a/src/argument_functions.rs
+++ b/src/argument_functions.rs
@@ -117,8 +117,8 @@ pub fn edit(matches: EditArgs, database: &mut OTPDatabase) -> Result<String, Str
                 if matches.pin.is_some() {
                     element.pin = matches.pin;
                 }
-                if secret.is_some() {
-                    element.secret = secret.unwrap();
+                if let Some(s) = secret {
+                    element.secret = s;
                 }
                 database.mark_modified();
             }

--- a/src/argument_functions.rs
+++ b/src/argument_functions.rs
@@ -108,6 +108,9 @@ pub fn edit(matches: EditArgs, database: &mut OTPDatabase) -> Result<String, Str
                 if let Some(v) = matches.period {
                     element.period = v;
                 }
+                if let Some(v) = matches.algorithm {
+                    element.algorithm = v;
+                }
                 if matches.counter.is_some() {
                     element.counter = matches.counter;
                 }

--- a/src/importers/aegis.rs
+++ b/src/importers/aegis.rs
@@ -1,4 +1,4 @@
-use std::fs::read_to_string;
+use std::{fs::read_to_string, path::PathBuf};
 
 use serde::Deserialize;
 use serde_json;
@@ -44,7 +44,7 @@ struct AegisInfo {
     counter: Option<u64>,
 }
 
-pub fn import(filepath: &str) -> Result<Vec<OTPElement>, String> {
+pub fn import(filepath: PathBuf) -> Result<Vec<OTPElement>, String> {
     let file_to_import_contents = match read_to_string(filepath) {
         Ok(result) => result,
         Err(e) => return Err(format!("Error during file reading: {e:?}")),

--- a/src/importers/aegis_encrypted.rs
+++ b/src/importers/aegis_encrypted.rs
@@ -6,6 +6,7 @@ use hex::FromHex;
 use serde::Deserialize;
 use serde_json;
 use std::fs::read_to_string;
+use std::path::PathBuf;
 use zeroize::Zeroize;
 
 use crate::otp::otp_element::OTPElement;
@@ -46,7 +47,7 @@ struct AegisEncryptedSlot {
     //repaired: Option<bool>,
 }
 
-pub fn import(filepath: &str, password: &str) -> Result<Vec<OTPElement>, String> {
+pub fn import(filepath: PathBuf, password: &str) -> Result<Vec<OTPElement>, String> {
     let file_to_import_contents = match read_to_string(filepath) {
         Ok(result) => result,
         Err(e) => return Err(format!("Error during file reading: {e:?}")),

--- a/src/importers/and_otp.rs
+++ b/src/importers/and_otp.rs
@@ -1,9 +1,9 @@
-use std::fs::read_to_string;
+use std::{fs::read_to_string, path::PathBuf};
 
 use crate::otp::otp_element::OTPElement;
 
 //no need to declare andOTP json struct cause it's the same as OTP element
-pub fn import(filepath: &str) -> Result<Vec<OTPElement>, String> {
+pub fn import(filepath: PathBuf) -> Result<Vec<OTPElement>, String> {
     let file_to_import_contents = match read_to_string(filepath) {
         Ok(result) => result,
         Err(e) => return Err(format!("Error during file reading: {e:?}")),

--- a/src/importers/authy_remote_debug.rs
+++ b/src/importers/authy_remote_debug.rs
@@ -7,7 +7,7 @@ For more information see https://gist.github.com/gboudreau/94bb0c11a6209c82418d0
 
 use serde::Deserialize;
 use serde_json;
-use std::fs::read_to_string;
+use std::{fs::read_to_string, path::PathBuf};
 
 use crate::otp::{otp_algorithm::OTPAlgorithm, otp_element::OTPElement, otp_type::OTPType};
 
@@ -64,7 +64,7 @@ impl AuthyExportedJsonElement {
     }
 }
 
-pub fn import(file_path: &str) -> Result<Vec<OTPElement>, String> {
+pub fn import(file_path: PathBuf) -> Result<Vec<OTPElement>, String> {
     let json = match read_to_string(file_path) {
         Ok(r) => r,
         Err(e) => return Err(format!("{e:?}")),

--- a/src/importers/converted.rs
+++ b/src/importers/converted.rs
@@ -1,4 +1,4 @@
-use std::fs::read_to_string;
+use std::{fs::read_to_string, path::PathBuf};
 
 use serde::Deserialize;
 use serde_json;
@@ -17,7 +17,7 @@ struct ConvertedJson {
     counter: u64,
 }
 
-pub fn import(filepath: &str) -> Result<Vec<OTPElement>, String> {
+pub fn import(filepath: PathBuf) -> Result<Vec<OTPElement>, String> {
     let file_to_import_contents = match read_to_string(filepath) {
         Ok(result) => result,
         Err(e) => return Err(format!("Error during file reading: {e:?}")),

--- a/src/importers/cotp.rs
+++ b/src/importers/cotp.rs
@@ -1,8 +1,8 @@
-use std::fs::read_to_string;
+use std::{fs::read_to_string, path::PathBuf};
 
 use crate::otp::otp_element::{OTPDatabase, OTPElement};
 
-pub fn import(filepath: &str) -> Result<Vec<OTPElement>, String> {
+pub fn import(filepath: PathBuf) -> Result<Vec<OTPElement>, String> {
     let file_to_import_contents = match read_to_string(filepath) {
         Ok(result) => result,
         Err(e) => return Err(format!("Error during file reading: {e:?}")),

--- a/src/importers/freeotp_plus.rs
+++ b/src/importers/freeotp_plus.rs
@@ -1,4 +1,4 @@
-use std::fs::read_to_string;
+use std::{fs::read_to_string, path::PathBuf};
 
 use data_encoding::BASE32_NOPAD;
 use serde::Deserialize;
@@ -28,7 +28,7 @@ struct FreeOTPElement {
     _type: String,
 }
 
-pub fn import(file_path: &str) -> Result<Vec<OTPElement>, String> {
+pub fn import(file_path: PathBuf) -> Result<Vec<OTPElement>, String> {
     let json = match read_to_string(file_path) {
         Ok(r) => r,
         Err(e) => return Err(format!("{e:?}")),

--- a/src/interface/handler.rs
+++ b/src/interface/handler.rs
@@ -155,6 +155,7 @@ fn main_handler(key_event: KeyEvent, app: &mut App) {
             let info_text = String::from(
                 "
             Press:
+            d -> Delete selected code
             + -> Increment the HOTP counter
             - -> Decrement the HOTP counter
             k -> Show QRCode of the selected element

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
-use args::get_matches;
+use args::CotpArgs;
+use clap::Parser;
 use interface::app::AppResult;
 use interface::event::{Event, EventHandler};
 use interface::handler::handle_key_events;
@@ -48,7 +49,7 @@ fn init() -> Result<ReadResult, String> {
 }
 
 fn main() -> AppResult<()> {
-    let matches = get_matches();
+    let cotp_args = CotpArgs::parse();
     let mut result = match init() {
         Ok(v) => v,
         Err(e) => {
@@ -56,7 +57,7 @@ fn main() -> AppResult<()> {
             std::process::exit(-1);
         }
     };
-    match args::args_parser(matches, &mut result.0) {
+    match args::args_parser(cotp_args, &mut result.0) {
         // no args, show dashboard
         None => match dashboard(result) {
             Ok(()) => std::process::exit(0),

--- a/src/otp/otp_algorithm.rs
+++ b/src/otp/otp_algorithm.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, ValueEnum)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, ValueEnum, Hash)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum OTPAlgorithm {
     Sha1,

--- a/src/otp/otp_algorithm.rs
+++ b/src/otp/otp_algorithm.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, ValueEnum)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum OTPAlgorithm {
     Sha1,

--- a/src/otp/otp_element.rs
+++ b/src/otp/otp_element.rs
@@ -25,7 +25,7 @@ use super::{
 
 pub const CURRENT_DATABASE_VERSION: u16 = 2;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Hash)]
 pub struct OTPDatabase {
     pub(crate) version: u16,
     pub(crate) elements: Vec<OTPElement>,
@@ -106,22 +106,21 @@ impl OTPDatabase {
     }
 
     pub fn add_all(&mut self, mut elements: Vec<OTPElement>) {
-        self.needs_modification = true;
+        self.mark_modified();
         self.elements.append(&mut elements)
     }
 
     pub fn add_element(&mut self, element: OTPElement) {
-        self.needs_modification = true;
+        self.mark_modified();
         self.elements.push(element)
     }
 
-    pub fn edit_element(&mut self, index: usize, element: OTPElement) {
+    pub fn mark_modified(&mut self) {
         self.needs_modification = true;
-        self.elements[index] = element;
     }
 
     pub fn delete_element(&mut self, index: usize) {
-        self.needs_modification = true;
+        self.mark_modified();
         self.elements.remove(index);
     }
 
@@ -146,7 +145,7 @@ impl OTPDatabase {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct OTPElement {
     pub secret: String,
     pub issuer: String,

--- a/src/otp/otp_type.rs
+++ b/src/otp/otp_type.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, ValueEnum)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, ValueEnum, Hash)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum OTPType {
     #[serde(alias = "totp")]

--- a/src/otp/otp_type.rs
+++ b/src/otp/otp_type.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, ValueEnum)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum OTPType {
     #[serde(alias = "totp")]


### PR DESCRIPTION
Better to use clap derive api to reduce boilerplate and errors.

Also we got a test that prevents common args parsing errors.