### PR TITLE
Implement extract subcommand and password insertion through stdin

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -141,6 +141,10 @@ pub struct ExtractArgs {
     /// Code label
     #[arg(short, long, required_unless_present_any=["index", "issuer"])]
     pub label: Option<String>,
+
+    /// Copy the code to the clipboard
+    #[arg(short, long = "copy-clipboard", default_value_t = false)]
+    pub copy_to_clipboard: bool,
 }
 
 #[derive(Args)]

--- a/src/argument_functions.rs
+++ b/src/argument_functions.rs
@@ -1,4 +1,4 @@
-use crate::args::{AddArgs, EditArgs, ExportArgs, ImportArgs};
+use crate::args::{AddArgs, EditArgs, ExportArgs, ExtractArgs, ImportArgs};
 use crate::exporters::do_export;
 use crate::exporters::otp_uri::OtpUriList;
 use crate::importers::aegis::AegisJson;
@@ -8,7 +8,7 @@ use crate::importers::converted::ConvertedJsonList;
 use crate::importers::freeotp_plus::FreeOTPPlusJson;
 use crate::importers::importer::import_from_path;
 use crate::otp::otp_element::{OTPDatabase, OTPElement};
-use crate::utils;
+use crate::{clipboard, utils};
 use color_eyre::eyre::{eyre, ErrReport};
 use zeroize::Zeroize;
 
@@ -156,6 +156,38 @@ pub fn export(matches: ExportArgs, database: OTPDatabase) -> color_eyre::Result<
         database
     })
     .map_err(|e| eyre!("An error occurred while exporting database: {e}"))
+}
+
+pub fn extract(args: ExtractArgs, database: OTPDatabase) -> color_eyre::Result<OTPDatabase> {
+    let first_with_filters = database
+        .elements
+        .iter()
+        .enumerate()
+        // Filter by index
+        .filter(|(index, _)| args.index.map_or(true, |i| i == *index))
+        .map(|(_, code)| code)
+        // Filter by issuer
+        .filter(|code| {
+            args.issuer.as_ref().map_or(true, |issuer| {
+                code.issuer.to_lowercase() == issuer.to_lowercase()
+            })
+        })
+        // Filter by label
+        .filter(|code| {
+            args.label.as_ref().map_or(true, |label| {
+                code.label.to_lowercase() == label.to_lowercase()
+            })
+        })
+        .next();
+
+    if let Some(otp) = first_with_filters {
+        let code = otp.get_otp_code()?;
+        let _ = clipboard::copy_string_to_clipboard(code.as_str())?;
+        println!("{}", code);
+        Ok(database)
+    } else {
+        Err(eyre!("No such code found with these fields"))
+    }
 }
 
 pub fn change_password(mut database: OTPDatabase) -> color_eyre::Result<OTPDatabase> {

--- a/src/argument_functions.rs
+++ b/src/argument_functions.rs
@@ -182,8 +182,11 @@ pub fn extract(args: ExtractArgs, database: OTPDatabase) -> color_eyre::Result<O
 
     if let Some(otp) = first_with_filters {
         let code = otp.get_otp_code()?;
-        let _ = clipboard::copy_string_to_clipboard(code.as_str())?;
         println!("{}", code);
+        if args.copy_to_clipboard {
+            let _ = clipboard::copy_string_to_clipboard(code.as_str())?;
+            println!("Copied to clipboard");
+        }
         Ok(database)
     } else {
         Err(eyre!("No such code found with these fields"))

--- a/src/argument_functions.rs
+++ b/src/argument_functions.rs
@@ -163,7 +163,6 @@ pub fn extract(args: ExtractArgs, database: OTPDatabase) -> color_eyre::Result<O
         .elements
         .iter()
         .enumerate()
-        // Filter by index
         .find(|(index, code)| filter_extract(&args, index, code))
         .map(|(_, code)| code);
 
@@ -199,5 +198,6 @@ fn filter_extract(args: &ExtractArgs, index: &usize, code: &OTPElement) -> bool 
     let match_by_label = args.label.as_ref().map_or(true, |label| {
         code.label.to_lowercase() == label.to_lowercase()
     });
+
     match_by_index && match_by_issuer && match_by_label
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,4 +1,5 @@
 use base64::{engine::general_purpose, Engine as _};
+use color_eyre::eyre::eyre;
 use copypasta_ext::prelude::*;
 #[cfg(target_os = "linux")]
 use copypasta_ext::wayland_bin::WaylandBinClipboardContext;
@@ -12,13 +13,13 @@ pub enum CopyType {
     OSC52,
 }
 
-pub fn copy_string_to_clipboard(content: String) -> Result<CopyType, ()> {
-    if ssh_clipboard(content.as_str()) {
+pub fn copy_string_to_clipboard(content: &str) -> color_eyre::Result<CopyType> {
+    if ssh_clipboard(content) {
         Ok(CopyType::OSC52)
-    } else if wayland_clipboard(content.as_str()) || other_platform_clipboard(content.as_str()) {
+    } else if wayland_clipboard(content) || other_platform_clipboard(content) {
         Ok(CopyType::Native)
     } else {
-        Err(())
+        Err(eyre!("Cannot detect clipboard implementation"))
     }
 }
 

--- a/src/interface/handler.rs
+++ b/src/interface/handler.rs
@@ -217,7 +217,7 @@ fn copy_selected_code_to_clipboard(app: &mut App) -> String {
         Some(selected) => match app.table.items.get(selected) {
             Some(element) => match element.values.get(3) {
                 Some(otp_code) => {
-                    if let Ok(result) = copy_string_to_clipboard(otp_code.to_owned()) {
+                    if let Ok(result) = copy_string_to_clipboard(otp_code) {
                         match result {
                             CopyType::Native => "Copied!".to_string(),
                             CopyType::OSC52 => "Remote copied!".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn main() -> AppResult<()> {
     let error_code = if reowned_database.is_modified() {
         match reowned_database.save(&key, &salt) {
             Ok(_) => {
-                println!("Success");
+                println!("Modifications has been persisted");
                 0
             }
             Err(_) => {
@@ -80,7 +80,6 @@ fn main() -> AppResult<()> {
             }
         }
     } else {
-        println!("Success");
         0
     };
     key.zeroize();

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -15,7 +15,7 @@ pub fn get_elements_from_input() -> color_eyre::Result<ReadResult> {
 }
 
 pub fn get_elements_from_stdin() -> color_eyre::Result<ReadResult> {
-    for password in io::stdin().lock().lines() {
+    if let Some(password) = io::stdin().lock().lines().next() {
         return get_elements_with_password(password?);
     }
     Err(eyre!("Failure during stdin reading"))

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -4,15 +4,26 @@ use crate::path::get_db_path;
 use crate::utils;
 use color_eyre::eyre::{eyre, ErrReport};
 use std::fs::read_to_string;
-use std::io;
+use std::io::{self, BufRead};
 use zeroize::Zeroize;
 
 pub type ReadResult = (OTPDatabase, Vec<u8>, Vec<u8>);
 
-pub fn get_elements() -> color_eyre::Result<ReadResult> {
-    let mut pw = utils::password("Password: ", 8);
-    let (elements, key, salt) = read_from_file(&pw)?;
-    pw.zeroize();
+pub fn get_elements_from_input() -> color_eyre::Result<ReadResult> {
+    let pw = utils::password("Password: ", 8);
+    get_elements_with_password(pw)
+}
+
+pub fn get_elements_from_stdin() -> color_eyre::Result<ReadResult> {
+    for password in io::stdin().lock().lines() {
+        return get_elements_with_password(password?);
+    }
+    Err(eyre!("Failure during stdin reading"))
+}
+
+fn get_elements_with_password(mut password: String) -> color_eyre::Result<ReadResult> {
+    let (elements, key, salt) = read_from_file(&password)?;
+    password.zeroize();
     Ok((elements, key, salt))
 }
 


### PR DESCRIPTION
Extract subcommand prints the code of the selected OTP code.
Password insertion through standard input permits non interactive access to OTP codes.