### PR TITLE
zeroize: Downgrade to `1.7.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1966,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ dirs = "5.0.1"
 rpassword = "7.3.1"
 data-encoding = "2.6.0"
 copypasta-ext = "0.4.4"
-zeroize = { version = "1.8.0", features = ["zeroize_derive"]}
+zeroize = { version = "1.7.0", features = ["zeroize_derive"]}
 clap = { version = "4.5.4", features = ["derive"] }
 hmac = "0.12.1"
 sha-1 = "0.10.1"


### PR DESCRIPTION
<details>
	<summary>logs</summary>

```
❯ cargo install --git https://github.com/replydev/cotp
    Updating git repository `https://github.com/replydev/cotp`
  Installing cotp v1.6.1 (https://github.com/replydev/cotp#1cf2cd41)
    Updating crates.io index
error: failed to compile `cotp v1.6.1 (https://github.com/replydev/cotp#1cf2cd41)`, intermediate artifacts can be found at `~\AppData\Local\Temp\cargo-installQt0z3i`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  failed to select a version for the requirement `zeroize = "^1.8.0"`
  candidate versions found which didn't match: 1.7.0, 1.6.0, 1.5.7, ...
  location searched: crates.io index
  required by package `cotp v1.6.1 (~\scoop\persist\rustup-msvc\.cargo\git\checkouts\cotp-e65676f91c34683e\1cf2cd4)`
  perhaps a crate was updated and forgotten to be re-vendored?

❯ cargo c
  Downloaded aead v0.5.1
  Downloaded arrayvec v0.7.2
  Downloaded time-core v0.1.1
  Downloaded strum v0.26.1
  Downloaded strum_macros v0.26.1
  Downloaded scopeguard v1.1.0
  Downloaded rtoolbox v0.0.1
  Downloaded pbkdf2 v0.12.1
  Downloaded parking_lot_core v0.9.4
  Downloaded itoa v1.0.4
  Downloaded cipher v0.4.3
  Downloaded chacha20 v0.9.0
  Downloaded anstyle-parse v0.2.0
  Downloaded anstyle v1.0.0
  Downloaded lock_api v0.4.9
  Downloaded indoc v2.0.3
  Downloaded ghash v0.5.0
  Downloaded constant_time_eq v0.1.5
  Downloaded bytemuck v1.12.1
  Downloaded base64ct v1.5.3
  Downloaded arrayref v0.3.6
  Downloaded image v0.25.0
  Downloaded 22 crates (9.6 MB) in 1.09s (largest was `image` at 9.2 MB)
    Checking cfg-if v1.0.0
   Compiling version_check v0.9.4
   Compiling typenum v1.15.0
   Compiling proc-macro2 v1.0.76
   Compiling unicode-ident v1.0.5
    Checking subtle v2.4.1
    Checking once_cell v1.18.0
   Compiling autocfg v1.1.0
   Compiling windows_x86_64_msvc v0.48.0
   Compiling winapi v0.3.9
    Checking cpufeatures v0.2.5
   Compiling windows_x86_64_msvc v0.52.0
   Compiling rustversion v1.0.14
   Compiling windows_x86_64_msvc v0.42.0
    Checking lazy_static v1.4.0
   Compiling parking_lot_core v0.9.4
    Checking opaque-debug v0.3.0
    Checking tinyvec_macros v0.1.1
    Checking utf8parse v0.2.1
    Checking getrandom v0.2.14
   Compiling cc v1.0.83
    Checking sharded-slab v0.1.7
    Checking smallvec v1.10.0
    Checking anstyle v1.0.0
    Checking pin-project-lite v0.2.13
    Checking scopeguard v1.1.0
    Checking zerocopy v0.7.31
    Checking tracing-core v0.1.31
    Checking rand_core v0.6.4
    Checking thread_local v1.1.7
   Compiling lock_api v0.4.9
   Compiling num-traits v0.2.15
   Compiling generic-array v0.14.6
   Compiling ahash v0.8.6
    Checking anstyle-parse v0.2.0
    Checking tinyvec v1.6.0
   Compiling heck v0.4.1
    Checking itoa v1.0.4
   Compiling serde v1.0.200
   Compiling paste v1.0.14
    Checking windows-targets v0.52.0
    Checking windows-targets v0.48.0
    Checking allocator-api2 v0.2.16
    Checking windows-sys v0.42.0
    Checking colorchoice v1.0.0
    Checking ryu v1.0.11
    Checking lazy-bytes-cast v5.0.1
   Compiling eyre v0.6.8
    Checking percent-encoding v2.3.1
    Checking unicode-bidi v0.3.13
    Checking tracing-subscriber v0.3.17
    Checking tracing v0.1.37
    Checking windows-sys v0.48.0
    Checking windows-sys v0.52.0
    Checking arrayvec v0.7.2
    Checking owo-colors v3.5.0
   Compiling heck v0.5.0
   Compiling copypasta-ext v0.4.4
   Compiling serde_json v1.0.116
    Checking arrayref v0.3.6
   Compiling backtrace v0.3.69
    Checking bytemuck v1.12.1
    Checking unicode-normalization v0.1.22
    Checking constant_time_eq v0.1.5
    Checking base64ct v1.5.3
    Checking rustc-demangle v0.1.23
    Checking indenter v0.3.3
    Checking bitflags v2.3.3
    Checking option-ext v0.2.0
    Checking clap_lex v0.7.0
    Checking anstyle-wincon v3.0.2
    Checking byteorder v1.4.3
    Checking tracing-error v0.2.0
    Checking time-core v0.1.1
    Checking either v1.8.0
    Checking strsim v0.11.0
    Checking static_assertions v1.1.0
    Checking password-hash v0.5.0
    Checking idna v0.5.0
    Checking blake2b_simd v1.0.0
    Checking form_urlencoded v1.2.1
    Checking time v0.3.23
    Checking unicode-segmentation v1.10.0
   Compiling indoc v2.0.3
    Checking itertools v0.12.0
    Checking unicode-width v0.1.10
    Checking color-spantrace v0.2.0
   Compiling quote v1.0.35
   Compiling cotp v1.6.1 (~\Documents\GitHub\cotp)
    Checking constant_time_eq v0.3.0
    Checking base64 v0.21.7
    Checking cassowary v0.3.0
    Checking urlencoding v2.1.3
    Checking hex v0.4.3
    Checking data-encoding v2.6.0
    Checking base64 v0.22.1
error[E0635]: unknown feature `stdsimd`
  --> ~\scoop\persist\rustup-msvc\.cargo\registry\src\index.crates.io-6f17d22bba15001f\ahash-0.8.6\src/lib.rs:99:42
   |
99 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
   |                                          ^^^^^^^

For more information about this error, try `rustc --explain E0635`.
    Checking url v2.5.0
error: could not compile `ahash` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...

❯ cargo --version
cargo 1.80.0-nightly (05364cb2f 2024-05-03)
```
</details>

- Seems like `zeroize` `1.8.0` was pulled https://crates.io/crates/zeroize/versions (clearing cargo cache doesn't help).
- `ahash` update was required for fixing `cargo check`
