### PR TITLE
Update README.md: COTP_DB_PATH env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ It will convert the database in a json format readable by cotp.
 To terminate the import:
 `cotp import --authy --path path/to/converted_database.json`
 
+# Configuration
+
+By default database is located in `$HOME/.cotp/db.cotp`. If you want to use a different path, you can use `COTP_DB_PATH` environment variable. 
+Here is an example of how to do this in bash:
+```bash
+$ COTP_DB_PATH=/home/user/.local/custom-folder/db.cotp /usr/bin/cotp
+```
+
 # Planned features
 
 Currently, there is not any planned feature. If you need something new that could improve the software feel free to open


### PR DESCRIPTION
Hi @replydev !

Thanks again for your marvelous tool, I wanted to synchronize my database across my devices, which required to put in under custom path. I didn't found the line README about this functionality, so I though it would be nice to add it there.

It would be nice to have some `cotp.config` file one day in the future, but since now it only holds one variable, it doesn't seem so important.

UPD: After making this I realized that it would also be nice to add this info in the `help` message or even add a flag to specify database path. I can modify the help message if you like, but I'm not so sure I'll have time to add a new flag (I don't know rust, so it'll take some additional time). Do you want me to update help message as well?