### PR TITLE
Feature request: deleting entries from the commandline 

### DIFF
--- a/src/arguments/delete.rs
+++ b/src/arguments/delete.rs
@@ -1,4 +1,4 @@
-use std::io::{self};
+use std::io::{self, Write};
 
 use clap::Args;
 use color_eyre::eyre::eyre;
@@ -33,14 +33,17 @@ impl SubcommandExecutor for DeleteArgs {
         let mut output = String::with_capacity(1);
 
         let element = otp_database.elements_ref().get(index_to_delete).unwrap();
-        println!(
+        print!(
             "Are you sure you want to delete the {}th code ({}, {}) [Y,N]: ",
-            index_to_delete, element.issuer, element.label
+            index_to_delete + 1,
+            element.issuer,
+            element.label
         );
+        io::stdout().flush()?;
 
         io::stdin().read_line(&mut output)?;
 
-        if output.eq_ignore_ascii_case("y") {
+        if output.trim().eq_ignore_ascii_case("y") {
             otp_database.delete_element(index_to_delete);
             Ok(otp_database)
         } else {

--- a/src/arguments/delete.rs
+++ b/src/arguments/delete.rs
@@ -61,15 +61,12 @@ fn get_first_matching_element(
         .iter()
         .enumerate()
         .find(|(_, element)| {
-            element.issuer.contains(
-                delete_args
-                    .issuer
-                    .as_ref()
-                    .map(|s| s.as_str())
-                    .unwrap_or(""),
-            ) && element
-                .label
-                .contains(delete_args.label.as_ref().map(|s| s.as_str()).unwrap_or(""))
+            element
+                .issuer
+                .contains(delete_args.issuer.as_deref().unwrap_or_default())
+                && element
+                    .label
+                    .contains(delete_args.label.as_deref().unwrap_or_default())
         })
         .map(|(index, _)| index)
 }

--- a/src/arguments/delete.rs
+++ b/src/arguments/delete.rs
@@ -1,0 +1,72 @@
+use std::io::{self};
+
+use clap::Args;
+use color_eyre::eyre::eyre;
+
+use crate::otp::otp_element::OTPDatabase;
+
+use super::SubcommandExecutor;
+
+#[derive(Args)]
+pub struct DeleteArgs {
+    /// Code Index
+    #[arg(short, long, required_unless_present_any=["issuer", "label"])]
+    pub index: Option<usize>,
+
+    /// Issuer of the first matching code that will be deleted
+    #[arg(short = 's', long, required_unless_present_any=["index", "label"])]
+    pub issuer: Option<String>,
+
+    /// Label of the first matching code that will be deleted
+    #[arg(short, long, required_unless_present_any=["index","issuer"])]
+    pub label: Option<String>,
+}
+
+impl SubcommandExecutor for DeleteArgs {
+    fn run_command(self, mut otp_database: OTPDatabase) -> color_eyre::Result<OTPDatabase> {
+        let index_to_delete = self
+            .index
+            .and_then(|i| i.checked_sub(1))
+            .or_else(|| get_first_matching_element(&otp_database, &self))
+            .ok_or(eyre!("No code has been found using the given arguments"))?;
+
+        let mut output = String::with_capacity(1);
+
+        let element = otp_database.elements_ref().get(index_to_delete).unwrap();
+        println!(
+            "Are you sure you want to delete the {}th code ({}, {}) [Y,N]: ",
+            index_to_delete, element.issuer, element.label
+        );
+
+        io::stdin().read_line(&mut output)?;
+
+        if output.eq_ignore_ascii_case("y") {
+            otp_database.delete_element(index_to_delete);
+            Ok(otp_database)
+        } else {
+            Err(eyre!("Operation interrupt by the user"))
+        }
+    }
+}
+
+fn get_first_matching_element(
+    otp_database: &OTPDatabase,
+    delete_args: &DeleteArgs,
+) -> Option<usize> {
+    otp_database
+        .elements_ref()
+        .iter()
+        .enumerate()
+        .find(|(_, element)| {
+            element.issuer.contains(
+                delete_args
+                    .issuer
+                    .as_ref()
+                    .map(|s| s.as_str())
+                    .unwrap_or(""),
+            ) && element
+                .label
+                .contains(delete_args.label.as_ref().map(|s| s.as_str()).unwrap_or(""))
+        })
+        .map(|(index, _)| index)
+}

--- a/src/arguments/mod.rs
+++ b/src/arguments/mod.rs
@@ -10,6 +10,7 @@ use self::{
 };
 
 mod add;
+mod delete;
 mod edit;
 mod export;
 mod extract;

--- a/src/arguments/mod.rs
+++ b/src/arguments/mod.rs
@@ -2,6 +2,7 @@ use crate::otp::otp_element::OTPDatabase;
 use crate::{arguments::extract::ExtractArgs, dashboard};
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::eyre;
+use delete::DeleteArgs;
 use enum_dispatch::enum_dispatch;
 
 use self::{
@@ -45,6 +46,8 @@ pub enum CotpSubcommands {
     Edit(EditArgs),
     /// List codes
     List(ListArgs),
+    /// Delete codes
+    Delete(DeleteArgs),
     /// Import codes from other apps
     Import(ImportArgs),
     /// Export cotp database


### PR DESCRIPTION
This PR adds a new sub-command that deletes codes based on their index, issuer or label.

Note, deletion of OTP codes it's also supported in the interative dashboard by selecting the desired code and then typing 'd'.