### PR TITLE
fix: cargo clippy

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,17 @@
-use std::env;
-use std::process::Command;
+use std::{env, process::Command};
 
 fn main() {
     let version = env!("CARGO_PKG_VERSION");
 
     if Ok("release".to_owned()) == env::var("PROFILE") {
-        println!("cargo:rustc-env=COTP_VERSION={}", version);
+        println!("cargo:rustc-env=COTP_VERSION={version}");
     } else {
         // Suffix with -DEBUG
         // If we can get the last commit hash, let's append that also
         if let Some(last_commit) = get_last_commit() {
-            println!(
-                "cargo:rustc-env=COTP_VERSION={}-DEBUG-{}",
-                version, last_commit
-            );
+            println!("cargo:rustc-env=COTP_VERSION={version}-DEBUG-{last_commit}");
         } else {
-            println!("cargo:rustc-env=COTP_VERSION={}-DEBUG", version);
+            println!("cargo:rustc-env=COTP_VERSION={version}-DEBUG");
         }
     }
 }
@@ -27,5 +23,5 @@ fn get_last_commit() -> Option<String> {
         .ok()
         .filter(|e| e.status.success())
         .map(|e| String::from_utf8(e.stdout))
-        .and_then(|e| e.ok())
+        .and_then(Result::ok)
 }

--- a/src/arguments/export.rs
+++ b/src/arguments/export.rs
@@ -37,7 +37,7 @@ pub struct ExportFormat {
     #[arg(short, long = "otp-uri")]
     pub otp_uri: bool,
 
-    /// Export into the FreeOTP+ database format
+    /// Export into the `FreeOTP`+ database format
     #[arg(short, long = "freeotp-plus")]
     pub freeotp_plus: bool,
 }

--- a/src/arguments/extract.rs
+++ b/src/arguments/extract.rs
@@ -30,12 +30,12 @@ impl SubcommandExecutor for ExtractArgs {
             .elements
             .iter()
             .enumerate()
-            .find(|(index, code)| filter_extract(&self, index, code))
+            .find(|(index, code)| filter_extract(&self, *index, code))
             .map(|(_, code)| code);
 
         if let Some(otp) = first_with_filters {
             let code = otp.get_otp_code()?;
-            println!("{}", code);
+            println!("{code}");
             if self.copy_to_clipboard {
                 let _ = clipboard::copy_string_to_clipboard(code.as_str())?;
                 println!("Copied to clipboard");
@@ -47,8 +47,8 @@ impl SubcommandExecutor for ExtractArgs {
     }
 }
 
-fn filter_extract(args: &ExtractArgs, index: &usize, code: &OTPElement) -> bool {
-    let match_by_index = args.index.map_or(true, |i| i == *index);
+fn filter_extract(args: &ExtractArgs, index: usize, code: &OTPElement) -> bool {
+    let match_by_index = args.index.map_or(true, |i| i == index);
 
     let match_by_issuer = args.issuer.as_ref().map_or(true, |issuer| {
         code.issuer.to_lowercase() == issuer.to_lowercase()

--- a/src/arguments/import.rs
+++ b/src/arguments/import.rs
@@ -44,11 +44,11 @@ pub struct BackupType {
     #[arg(short = 'k', long = "aegis-encrypted")]
     pub aegis_encrypted: bool,
 
-    /// Import from FreeOTP+ backup
+    /// Import from `FreeOTP`+ backup
     #[arg(short, long = "freeotp-plus")]
     pub freeotp_plus: bool,
 
-    /// Import from FreeOTP backup
+    /// Import from `FreeOTP` backup
     #[arg(short = 'r', long)]
     pub freeotp: bool,
 
@@ -60,7 +60,7 @@ pub struct BackupType {
     #[arg(short = 't', long)]
     pub authy: bool,
 
-    /// Import from Authy Database exported following this guide https://gist.github.com/gboudreau/94bb0c11a6209c82418d01a59d958c93
+    /// Import from Authy Database exported following this guide <https://gist.github.com/gboudreau/94bb0c11a6209c82418d01a59d958c93>
     #[arg(short = 'u', long = "authy-exported")]
     pub authy_exported: bool,
 

--- a/src/arguments/list.rs
+++ b/src/arguments/list.rs
@@ -64,7 +64,7 @@ impl SubcommandExecutor for ListArgs {
             let json_elements = otp_database
                 .elements
                 .iter()
-                .map(|element| element.try_into())
+                .map(TryInto::try_into)
                 .collect::<Result<Vec<JsonOtpList>>>()?;
 
             let stringified = serde_json::to_string_pretty(&json_elements)
@@ -104,13 +104,13 @@ impl SubcommandExecutor for ListArgs {
                                     .repeat(issuer_width - NO_ISSUER_TEXT.chars().count())
                                     .as_str()
                         } else {
-                            e.issuer.to_owned()
+                            e.issuer.clone()
                                 + " ".repeat(issuer_width - e.issuer.chars().count()).as_str()
                         },
-                        e.label.to_owned()
+                        e.label.clone()
                             + " ".repeat(label_width - e.label.chars().count()).as_str(),
                         e.get_otp_code().unwrap_or("ERROR".to_string())
-                    )
+                    );
                 });
         }
 

--- a/src/arguments/mod.rs
+++ b/src/arguments/mod.rs
@@ -72,5 +72,5 @@ pub fn args_parser(matches: CotpArgs, read_result: OTPDatabase) -> color_eyre::R
 #[test]
 fn verify_cli() {
     use clap::CommandFactory;
-    CotpArgs::command().debug_assert()
+    CotpArgs::command().debug_assert();
 }

--- a/src/crypto/cryptography.rs
+++ b/src/crypto/cryptography.rs
@@ -31,7 +31,7 @@ pub fn gen_salt() -> color_eyre::Result<[u8; ARGON2ID_SALT_LENGTH]> {
 }
 
 pub fn encrypt_string_with_key(
-    plain_text: String,
+    plain_text: &str,
     key: &Vec<u8>,
     salt: &[u8],
 ) -> color_eyre::Result<EncryptedDatabase> {
@@ -93,8 +93,7 @@ mod tests {
     fn test_encryption() {
         let salt = gen_salt().unwrap();
         let key = argon_derive_key(b"pa$$w0rd", salt.as_ref()).unwrap();
-        let encrypted =
-            encrypt_string_with_key(String::from("Secret data@#[]ò"), &key, salt.as_ref()).unwrap();
+        let encrypted = encrypt_string_with_key("Secret data@#[]ò", &key, salt.as_ref()).unwrap();
         let (decrypted, _key, _salt) =
             decrypt_string(&serde_json::to_string(&encrypted).unwrap(), "pa$$w0rd").unwrap();
         assert_eq!(String::from("Secret data@#[]ò"), decrypted);

--- a/src/exporters/freeotp_plus.rs
+++ b/src/exporters/freeotp_plus.rs
@@ -12,7 +12,7 @@ impl TryFrom<&OTPDatabase> for FreeOTPPlusJson {
         otp_database
             .elements
             .iter()
-            .map(|e| e.try_into())
+            .map(TryInto::try_into)
             .collect::<Result<Vec<FreeOTPElement>, ErrReport>>()
             .map(FreeOTPPlusJson::new)
     }
@@ -22,19 +22,19 @@ impl TryFrom<&OTPElement> for FreeOTPElement {
     type Error = ErrReport;
     fn try_from(otp_element: &OTPElement) -> Result<Self, Self::Error> {
         Ok(FreeOTPElement {
-            secret: decode_secret(otp_element.secret.clone())?,
+            secret: decode_secret(&otp_element.secret)?,
             algo: otp_element.algorithm.to_string(),
             counter: otp_element.counter.unwrap_or(0),
             digits: otp_element.digits,
             issuer_ext: otp_element.issuer.clone(),
-            _label: otp_element.label.clone(),
+            label: otp_element.label.clone(),
             period: otp_element.period,
-            _type: otp_element.type_.to_string(),
+            r#type: otp_element.type_.to_string(),
         })
     }
 }
 
-fn decode_secret(secret: String) -> Result<Vec<i8>> {
+fn decode_secret(secret: &str) -> Result<Vec<i8>> {
     BASE32_NOPAD
         .decode(secret.as_bytes())
         .map(|v| v.into_iter().map(|n| n as i8).collect::<Vec<i8>>())

--- a/src/exporters/otp_uri.rs
+++ b/src/exporters/otp_uri.rs
@@ -8,7 +8,7 @@ pub struct OtpUriList {
 
 impl<'a> From<&'a OTPDatabase> for OtpUriList {
     fn from(value: &'a OTPDatabase) -> Self {
-        let items: Vec<String> = value.elements.iter().map(|e| e.get_otpauth_uri()).collect();
+        let items: Vec<String> = value.elements.iter().map(super::super::otp::otp_element::OTPElement::get_otpauth_uri).collect();
 
         OtpUriList { items }
     }

--- a/src/exporters/otp_uri.rs
+++ b/src/exporters/otp_uri.rs
@@ -8,7 +8,11 @@ pub struct OtpUriList {
 
 impl<'a> From<&'a OTPDatabase> for OtpUriList {
     fn from(value: &'a OTPDatabase) -> Self {
-        let items: Vec<String> = value.elements.iter().map(super::super::otp::otp_element::OTPElement::get_otpauth_uri).collect();
+        let items: Vec<String> = value
+            .elements
+            .iter()
+            .map(super::super::otp::otp_element::OTPElement::get_otpauth_uri)
+            .collect();
 
         OtpUriList { items }
     }

--- a/src/importers/aegis.rs
+++ b/src/importers/aegis.rs
@@ -23,8 +23,7 @@ pub(crate) struct AegisDb {
 
 #[derive(Serialize, Deserialize)]
 struct AegisElement {
-    #[serde(rename = "type")]
-    _type: String,
+    r#type: String,
     //uuid: String,
     name: String,
     issuer: String,
@@ -39,7 +38,7 @@ impl From<AegisElement> for OTPElement {
             issuer: value.issuer,
             label: value.name,
             digits: value.info.digits,
-            type_: OTPType::from(value._type.as_str()),
+            type_: OTPType::from(value.r#type.as_str()),
             algorithm: OTPAlgorithm::from(value.info.algo.as_str()),
             period: value.info.period.unwrap_or(30),
             counter: value.info.counter,
@@ -52,7 +51,7 @@ impl TryFrom<AegisDb> for Vec<OTPElement> {
     type Error = String;
 
     fn try_from(aegis_db: AegisDb) -> Result<Self, Self::Error> {
-        Ok(aegis_db.entries.into_iter().map(|e| e.into()).collect())
+        Ok(aegis_db.entries.into_iter().map(Into::into).collect())
     }
 }
 

--- a/src/importers/aegis_encrypted.rs
+++ b/src/importers/aegis_encrypted.rs
@@ -33,8 +33,7 @@ struct AegisEncryptedParams {
 
 #[derive(Deserialize)]
 struct AegisEncryptedSlot {
-    #[serde(rename = "type")]
-    _type: u32,
+    r#type: u32,
     //uuid: String,
     key: String,
     key_params: AegisEncryptedParams,
@@ -93,7 +92,7 @@ fn get_master_key(aegis_encrypted: &AegisEncryptedDatabase, password: &str) -> O
         .header
         .slots
         .iter()
-        .filter(|item| item._type == 1)
+        .filter(|item| item.r#type == 1)
     {
         match calc_master_key(slot, password) {
             Ok(value) => {
@@ -112,7 +111,7 @@ fn map_results(decrypted_db: Vec<u8>) -> Result<Vec<OTPElement>, String> {
 
     serde_json::from_str::<AegisDb>(json.as_str())
         .map_err(|e| e.to_string())
-        .and_then(|e| e.try_into())
+        .and_then(TryInto::try_into)
 }
 
 fn get_params(slot: &AegisEncryptedSlot) -> Result<Params, String> {

--- a/src/importers/authy_remote_debug.rs
+++ b/src/importers/authy_remote_debug.rs
@@ -62,7 +62,7 @@ impl AuthyExportedJsonElement {
                 let issuer = args.first().unwrap_or(&default_value);
                 match urlencoding::decode(issuer) {
                     Ok(r) => r.into_owned(),
-                    Err(_e) => issuer.to_string(),
+                    Err(_e) => (*issuer).to_string(),
                 }
             }
             None => String::from(default_value),
@@ -91,6 +91,6 @@ impl From<AuthyExportedJsonElement> for OTPElement {
 
 impl From<AuthyExportedList> for Vec<OTPElement> {
     fn from(exported_list: AuthyExportedList) -> Self {
-        exported_list.0.into_iter().map(|e| e.into()).collect()
+        exported_list.0.into_iter().map(Into::into).collect()
     }
 }

--- a/src/importers/converted.rs
+++ b/src/importers/converted.rs
@@ -39,6 +39,6 @@ pub struct ConvertedJsonList(Vec<ConvertedJson>);
 impl TryFrom<ConvertedJsonList> for Vec<OTPElement> {
     type Error = String;
     fn try_from(value: ConvertedJsonList) -> Result<Self, Self::Error> {
-        Ok(value.0.into_iter().map(|e| e.into()).collect())
+        Ok(value.0.into_iter().map(Into::into).collect())
     }
 }

--- a/src/importers/freeotp_plus.rs
+++ b/src/importers/freeotp_plus.rs
@@ -11,15 +11,15 @@ pub struct FreeOTPPlusJson {
 }
 
 impl FreeOTPPlusJson {
-    /// Creates a new instance of FreeOTPPlusJSON. Currently we clone the tokens label to retrieve the tokens order.
+    /// Creates a new instance of `FreeOTPPlusJSON`. Currently we clone the tokens label to retrieve the tokens order.
     pub fn new(tokens: Vec<FreeOTPElement>) -> Self {
         let token_order: Vec<String> = tokens
             .iter()
             .map(|e| {
                 if e.issuer_ext.is_empty() {
-                    e._label.clone()
+                    e.label.clone()
                 } else {
-                    format!("{}:{}", e.issuer_ext, e._label)
+                    format!("{}:{}", e.issuer_ext, e.label)
                 }
             })
             .collect();
@@ -38,12 +38,10 @@ pub struct FreeOTPElement {
     pub digits: u64,
     #[serde(rename = "issuerExt")]
     pub issuer_ext: String,
-    #[serde(rename = "label")]
-    pub _label: String,
+    pub label: String,
     pub period: u64,
     pub secret: Vec<i8>,
-    #[serde(rename = "type")]
-    pub _type: String,
+    pub r#type: String,
 }
 
 impl From<FreeOTPElement> for OTPElement {
@@ -57,9 +55,9 @@ impl From<FreeOTPElement> for OTPElement {
             counter,
             secret: encode_secret(&token.secret),
             issuer: token.issuer_ext,
-            label: token._label,
+            label: token.label,
             digits: token.digits,
-            type_: OTPType::from(token._type.as_str()),
+            type_: OTPType::from(token.r#type.as_str()),
             algorithm: OTPAlgorithm::from(token.algo.as_str()),
             period: token.period,
             pin: None,
@@ -70,7 +68,7 @@ impl From<FreeOTPElement> for OTPElement {
 impl TryFrom<FreeOTPPlusJson> for Vec<OTPElement> {
     type Error = String;
     fn try_from(freeotp: FreeOTPPlusJson) -> Result<Self, Self::Error> {
-        Ok(freeotp.tokens.into_iter().map(|e| e.into()).collect())
+        Ok(freeotp.tokens.into_iter().map(Into::into).collect())
     }
 }
 
@@ -145,7 +143,7 @@ mod tests {
                 }
             ],
             imported.unwrap()
-        )
+        );
     }
 
     #[test]
@@ -174,7 +172,7 @@ mod tests {
                     counter: 0,
                     digits: 6,
                     issuer_ext: String::default(),
-                    _label: "label1".to_string(),
+                    label: "label1".to_string(),
                     period: 30,
                     secret: vec![
                         7, -40, 73, 126, -112, -25, 37, 28, 72, -39, 115, 50, -127, 46, 74, 117,
@@ -185,24 +183,24 @@ mod tests {
                         -61, 75, -38, -116, -122, 106, 79, 37, 82, -62, -125, -30, -27, 116, 116,
                         82, -55, 72, 87, 41, 15, -25, -27, 65, 6, -104, 49, -26, -111, 10
                     ],
-                    _type: "TOTP".to_string()
+                    r#type: "TOTP".to_string()
                 },
                 FreeOTPElement {
                     algo: "SHA256".to_string(),
                     counter: 3,
                     digits: 6,
                     issuer_ext: "ciccio".to_string(),
-                    _label: "label2".to_string(),
+                    label: "label2".to_string(),
                     period: 30,
                     secret: vec![
                         35, -75, 13, 47, -2, -128, -100, -27, 64, -115, -72, 14, -78, -122, 88, 62,
                         -32, 57, 37, -111, 90, -70, -58, -15, -113, 111, -94, 91, -90, 90, -91, 61,
                         -9, -23, 54, 4, -31, -93, -8, -9, 27, 125, -21, 112, -80, -30, 64, 46, 10
                     ],
-                    _type: "HOTP".to_string()
+                    r#type: "HOTP".to_string()
                 }
             ],
             free_otp.tokens
-        )
+        );
     }
 }

--- a/src/importers/otp_uri.rs
+++ b/src/importers/otp_uri.rs
@@ -47,6 +47,6 @@ mod tests {
 
         // Assert
         assert_eq!(1, imported.len());
-        assert_eq!(expected_element, imported.pop().unwrap())
+        assert_eq!(expected_element, imported.pop().unwrap());
     }
 }

--- a/src/interface/event.rs
+++ b/src/interface/event.rs
@@ -65,7 +65,7 @@ impl EventHandler {
                         CrosstermEvent::FocusLost => sender.send(Event::FocusLost()),
                         CrosstermEvent::Paste(_e) => sender.send(Event::Paste(())),
                     }
-                    .expect("failed to send terminal event")
+                    .expect("failed to send terminal event");
                 }
 
                 if last_tick.elapsed() >= tick_rate {

--- a/src/interface/handlers/main_window.rs
+++ b/src/interface/handlers/main_window.rs
@@ -22,7 +22,7 @@ pub(super) fn main_handler(key_event: KeyEvent, app: &mut App) {
             handle_exit(app);
         }
         // exit application on Ctrl-D
-        KeyCode::Char('d') | KeyCode::Char('D') | KeyCode::Char('c') => {
+        KeyCode::Char('d' | 'D' | 'c') => {
             if key_event.modifiers == KeyModifiers::CONTROL {
                 handle_exit(app);
             } else if app.table.state.selected().is_some() {
@@ -35,11 +35,11 @@ pub(super) fn main_handler(key_event: KeyEvent, app: &mut App) {
                         action: PopupAction::DeleteOtp,
                     },
                     app,
-                )
+                );
             }
         }
         // exit application on Q
-        KeyCode::Char('q') | KeyCode::Char('Q') => {
+        KeyCode::Char('q' | 'Q') => {
             if app.focus != Focus::SearchBar {
                 handle_exit(app);
             }
@@ -68,9 +68,9 @@ pub(super) fn main_handler(key_event: KeyEvent, app: &mut App) {
             handle_counter_switch(app, false);
         }
 
-        KeyCode::Char('k') | KeyCode::Char('K') => handle_switch_page(app, Qrcode),
+        KeyCode::Char('k' | 'K') => handle_switch_page(app, Qrcode),
 
-        KeyCode::Char('i') | KeyCode::Char('I') => {
+        KeyCode::Char('i' | 'I') => {
             let info_text = String::from(
                 "
             Press:
@@ -95,7 +95,7 @@ pub(super) fn main_handler(key_event: KeyEvent, app: &mut App) {
             );
         }
 
-        KeyCode::Char('f') | KeyCode::Char('F') => {
+        KeyCode::Char('f' | 'F') => {
             if key_event.modifiers == KeyModifiers::CONTROL {
                 app.focus = Focus::SearchBar;
             }

--- a/src/interface/handlers/mod.rs
+++ b/src/interface/handlers/mod.rs
@@ -5,7 +5,7 @@ use crate::clipboard::{copy_string_to_clipboard, CopyType};
 use self::{main_window::main_handler, popup::popup_handler, search_bar::search_bar_handler};
 
 use super::{
-    app::{App, AppResult, Popup},
+    app::{App, Popup},
     enums::{Focus, PopupAction},
 };
 
@@ -14,13 +14,12 @@ mod popup;
 mod search_bar;
 
 /// Handles the key events and updates the state of [`App`].
-pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
+pub fn handle_key_events(key_event: KeyEvent, app: &mut App) {
     match app.focus {
         Focus::MainPage => main_handler(key_event, app),
         Focus::SearchBar => search_bar_handler(key_event, app),
         Focus::Popup => popup_handler(key_event, app),
     }
-    Ok(())
 }
 
 pub(super) fn handle_exit(app: &mut App) {
@@ -33,7 +32,7 @@ pub(super) fn handle_exit(app: &mut App) {
                 action: PopupAction::SaveBeforeQuit,
             },
             app,
-        )
+        );
     } else {
         app.running = false;
     }

--- a/src/interface/handlers/popup.rs
+++ b/src/interface/handlers/popup.rs
@@ -9,7 +9,7 @@ pub(super) fn popup_handler(key_event: KeyEvent, app: &mut App) {
     match app.popup.action {
         PopupAction::EditOtp => todo!(),
         PopupAction::DeleteOtp => match key_event.code {
-            KeyCode::Char('y') | KeyCode::Char('Y') => {
+            KeyCode::Char('y' | 'Y') => {
                 if let Err(e) = delete_selected_code(app) {
                     app.popup.text = e;
                     return;
@@ -18,22 +18,22 @@ pub(super) fn popup_handler(key_event: KeyEvent, app: &mut App) {
                 // Force table render
                 app.tick(true);
             }
-            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+            KeyCode::Char('n' | 'N') | KeyCode::Esc => {
                 app.focus = Focus::MainPage;
             }
             _ => {}
         },
         PopupAction::GeneralInfo => match key_event.code {
-            KeyCode::Char('I') | KeyCode::Char('i') | KeyCode::Esc | KeyCode::Enter => {
+            KeyCode::Char('I' | 'i') | KeyCode::Esc | KeyCode::Enter => {
                 app.focus = Focus::MainPage;
             }
             _ => {}
         },
         PopupAction::SaveBeforeQuit => match key_event.code {
-            KeyCode::Char('y') | KeyCode::Char('Y') => {
+            KeyCode::Char('y' | 'Y') => {
                 app.running = false;
             }
-            KeyCode::Char('n') | KeyCode::Char('N') => {
+            KeyCode::Char('n' | 'N') => {
                 app.database.needs_modification = false;
                 app.running = false;
             }
@@ -54,7 +54,7 @@ fn delete_selected_code(app: &mut App) -> Result<String, String> {
                 if selected >= app.database.elements_ref().len() {
                     app.table.previous();
                 } else if app.database.elements_ref().is_empty() {
-                    app.table.state.select(None)
+                    app.table.state.select(None);
                 }
                 Ok("Done".to_string())
             } else {

--- a/src/interface/stateful_table.rs
+++ b/src/interface/stateful_table.rs
@@ -61,11 +61,11 @@ pub fn fill_table(table: &mut StatefulTable, elements: &[OTPElement]) {
         let label = match element.type_ {
             OTPType::Hotp => match element.counter {
                 Some(result) => {
-                    element.label.to_owned() + (format!(" ({result} counter)").as_str())
+                    element.label.clone() + (format!(" ({result} counter)").as_str())
                 }
-                None => element.label.to_owned(),
+                None => element.label.clone(),
             },
-            _ => element.label.to_owned(),
+            _ => element.label.clone(),
         };
         let result = element.get_otp_code();
 
@@ -73,7 +73,7 @@ pub fn fill_table(table: &mut StatefulTable, elements: &[OTPElement]) {
         table.items.push(Row::new(
             vec![
                 (i + 1).to_string(),
-                element.issuer.to_owned(),
+                element.issuer.clone(),
                 label,
                 match result {
                     Ok(code) => code,

--- a/src/interface/stateful_table.rs
+++ b/src/interface/stateful_table.rs
@@ -60,9 +60,7 @@ pub fn fill_table(table: &mut StatefulTable, elements: &[OTPElement]) {
     for (i, element) in elements.iter().enumerate() {
         let label = match element.type_ {
             OTPType::Hotp => match element.counter {
-                Some(result) => {
-                    element.label.clone() + (format!(" ({result} counter)").as_str())
-                }
+                Some(result) => element.label.clone() + (format!(" ({result} counter)").as_str()),
                 None => element.label.clone(),
             },
             _ => element.label.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,15 +73,12 @@ fn main() -> AppResult<()> {
     };
 
     let error_code = if reowned_database.is_modified() {
-        match reowned_database.save(&key, &salt) {
-            Ok(_) => {
-                println!("Modifications has been persisted");
-                0
-            }
-            Err(_) => {
-                eprintln!("An error occurred during database overwriting");
-                -1
-            }
+        if let Ok(()) = reowned_database.save(&key, &salt) {
+            println!("Modifications has been persisted");
+            0
+        } else {
+            eprintln!("An error occurred during database overwriting");
+            -1
         }
     } else {
         0
@@ -111,12 +108,12 @@ fn dashboard(mut database: OTPDatabase) -> AppResult<OTPDatabase> {
             // Handle events.
             match tui.events.next()? {
                 Event::Tick => app.tick(false),
-                Event::Key(key_event) => handle_key_events(key_event, &mut app)?,
-                Event::Mouse(_) => {}
-                Event::Resize(_, _) => {}
-                Event::FocusGained() => {}
-                Event::FocusLost() => {}
-                Event::Paste(_) => {}
+                Event::Key(key_event) => handle_key_events(key_event, &mut app),
+                Event::Mouse(())
+                | Event::Resize((), ())
+                | Event::FocusGained()
+                | Event::FocusLost()
+                | Event::Paste(()) => {}
             }
         }
 

--- a/src/otp/algorithms/motp_maker.rs
+++ b/src/otp/algorithms/motp_maker.rs
@@ -1,9 +1,7 @@
+use md5::{Digest, Md5};
 use std::time::SystemTime;
 
-use crate::otp::otp_error::OtpError;
-use md5::{Digest, Md5};
-
-pub fn motp(secret: &str, pin: &str, period: u64, digits: usize) -> Result<String, OtpError> {
+pub fn motp(secret: &str, pin: &str, period: u64, digits: usize) -> String {
     let seconds = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
@@ -12,13 +10,7 @@ pub fn motp(secret: &str, pin: &str, period: u64, digits: usize) -> Result<Strin
     get_motp_code(secret, pin, period, digits, seconds)
 }
 
-fn get_motp_code(
-    secret: &str,
-    pin: &str,
-    period: u64,
-    digits: usize,
-    seconds: u64,
-) -> Result<String, OtpError> {
+fn get_motp_code(secret: &str, pin: &str, period: u64, digits: usize, seconds: u64) -> String {
     // TODO MOTP Secrets are hex encoded, so do not use BASE32 at all
     let hex_secret = secret;
     let counter = seconds / period;
@@ -27,7 +19,7 @@ fn get_motp_code(
     let mut md5_hasher = Md5::new();
     md5_hasher.update(data.as_bytes());
     let code = hex::encode(md5_hasher.finalize());
-    Ok(code.as_str()[0..digits].to_owned())
+    code.as_str()[0..digits].to_owned()
 }
 
 #[cfg(test)]
@@ -40,8 +32,8 @@ mod tests {
         let seconds: u64 = 165892298;
 
         assert_eq!(
-            Ok("e7d8b6".to_string()),
+            "e7d8b6".to_string(),
             get_motp_code("e3152afee62599c8", "1234", 10, 6, seconds)
-        )
+        );
     }
 }

--- a/src/otp/algorithms/steam_otp_maker.rs
+++ b/src/otp/algorithms/steam_otp_maker.rs
@@ -29,6 +29,6 @@ mod tests {
 
     #[test]
     fn test_steam_code() {
-        assert_eq!(to_steam_string(36751792, 5), String::from("GJ2F4"))
+        assert_eq!(to_steam_string(36751792, 5), String::from("GJ2F4"));
     }
 }

--- a/src/otp/migrations/mod.rs
+++ b/src/otp/migrations/mod.rs
@@ -1,25 +1,27 @@
 use super::otp_element::OTPDatabase;
 struct Migration<'a> {
     to_version: u16, // Database version which we are migrating on
-    migration_function: &'a dyn Fn(&mut OTPDatabase), // Function to execute the migration
+    migration_function: &'a dyn Fn(&mut OTPDatabase) -> color_eyre::Result<()>, // Function to execute the migration
 }
 const MIGRATIONS_LIST: [Migration; 1] = [Migration {
     to_version: 2,
     migration_function: &migrate_to_2,
 }];
 
-fn migrate_to_2(database: &mut OTPDatabase) {
+fn migrate_to_2(database: &mut OTPDatabase) -> color_eyre::Result<()> {
     database.version = 2;
+    Ok(())
 }
 
-pub fn migrate(database: &mut OTPDatabase) {
+pub fn migrate(database: &mut OTPDatabase) -> color_eyre::Result<()> {
     let mut binding = MIGRATIONS_LIST;
     let migrations = binding.as_mut();
     migrations.sort_unstable_by(|c1, c2| c1.to_version.cmp(&c2.to_version));
     for i in migrations {
         if database.version < i.to_version {
             // Do the migration
-            (i.migration_function)(database);
+            (i.migration_function)(database)?;
         }
     }
+    Ok(())
 }

--- a/src/otp/migrations/mod.rs
+++ b/src/otp/migrations/mod.rs
@@ -1,27 +1,25 @@
 use super::otp_element::OTPDatabase;
 struct Migration<'a> {
     to_version: u16, // Database version which we are migrating on
-    migration_function: &'a dyn Fn(&mut OTPDatabase) -> color_eyre::Result<()>, // Function to execute the migration
+    migration_function: &'a dyn Fn(&mut OTPDatabase), // Function to execute the migration
 }
 const MIGRATIONS_LIST: [Migration; 1] = [Migration {
     to_version: 2,
     migration_function: &migrate_to_2,
 }];
 
-fn migrate_to_2(database: &mut OTPDatabase) -> color_eyre::Result<()> {
+fn migrate_to_2(database: &mut OTPDatabase) {
     database.version = 2;
-    Ok(())
 }
 
-pub fn migrate(database: &mut OTPDatabase) -> color_eyre::Result<()> {
+pub fn migrate(database: &mut OTPDatabase) {
     let mut binding = MIGRATIONS_LIST;
     let migrations = binding.as_mut();
     migrations.sort_unstable_by(|c1, c2| c1.to_version.cmp(&c2.to_version));
     for i in migrations {
         if database.version < i.to_version {
             // Do the migration
-            (i.migration_function)(database)?
+            (i.migration_function)(database);
         }
     }
-    Ok(())
 }

--- a/src/otp/otp_element.rs
+++ b/src/otp/otp_element.rs
@@ -59,7 +59,7 @@ impl OTPDatabase {
 
     pub fn save(&mut self, key: &Vec<u8>, salt: &[u8]) -> color_eyre::Result<()> {
         self.needs_modification = false;
-        migrate(self);
+        migrate(self)?;
         match self.overwrite_database_key(key, salt) {
             Ok(()) => Ok(()),
             Err(e) => Err(ErrReport::from(e)),

--- a/src/otp/otp_type.rs
+++ b/src/otp/otp_type.rs
@@ -57,6 +57,6 @@ impl From<&str> for OTPType {
 
 impl Zeroize for OTPType {
     fn zeroize(&mut self) {
-        *self = OTPType::Totp
+        *self = OTPType::Totp;
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -18,9 +18,7 @@ pub fn init_path(args: &CotpArgs) -> PathBuf {
             args.database_path
                 .as_ref()
                 .map(String::from)
-                .or(env::var("COTP_DB_PATH").ok())
-                .map(PathBuf::from)
-                .unwrap_or_else(get_default_db_path)
+                .or(env::var("COTP_DB_PATH").ok()).map_or_else(get_default_db_path, PathBuf::from)
         })
         .to_owned()
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -18,7 +18,8 @@ pub fn init_path(args: &CotpArgs) -> PathBuf {
             args.database_path
                 .as_ref()
                 .map(String::from)
-                .or(env::var("COTP_DB_PATH").ok()).map_or_else(get_default_db_path, PathBuf::from)
+                .or(env::var("COTP_DB_PATH").ok())
+                .map_or_else(get_default_db_path, PathBuf::from)
         })
         .to_owned()
 }

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -32,7 +32,7 @@ pub fn read_decrypted_text(password: &str) -> color_eyre::Result<(String, Vec<u8
         read_to_string(DATABASE_PATH.get().unwrap()).map_err(ErrReport::from)?;
     if encrypted_contents.is_empty() {
         return match delete_db() {
-            Ok(_) => Err(eyre!(
+            Ok(()) => Err(eyre!(
                 "Your database file was empty, please restart to create a new one.",
             )),
             Err(_) => Err(eyre!(
@@ -48,7 +48,7 @@ pub fn read_from_file(password: &str) -> color_eyre::Result<ReadResult> {
     match read_decrypted_text(password) {
         Ok((mut contents, key, salt)) => {
             let mut database: OTPDatabase = serde_json::from_str(&contents)
-                .or_else(|_| serde_json::from_str::<Vec<OTPElement>>(&contents).map(|r| r.into()))
+                .or_else(|_| serde_json::from_str::<Vec<OTPElement>>(&contents).map(Into::into))
                 .map_err(ErrReport::from)?;
             contents.zeroize();
             database.sort();


### PR DESCRIPTION
# clippy fixes

I think these fixes improves code quality.

> [!NOTE]
> `unreadable_literal` might also be usable, but I've excluded it for now.


command used:

```sh
cargo clippy -- \
    -W clippy::pedantic \
    -A clippy::cast_sign_loss \
    -A clippy::cast_possible_wrap \
    -A clippy::similar_names \
    -A clippy::must_use_candidate \
    -A clippy::return_self_not_must_use \
    -A clippy::cast_possible_truncation \
    -A clippy::default_trait_access \
    -A clippy::struct_excessive_bools \
    -A clippy::cast_lossless \
    -A clippy::wildcard_imports \
    -A clippy::cast_precision_loss \
    -A clippy::module_name_repetitions \
    -A clippy::unreadable_literal
```
