### PR TITLE
fix: `mismatched_lifetime_syntaxes` & clippy compiler warnings

### DIFF
--- a/src/interface/handlers/main_window.rs
+++ b/src/interface/handlers/main_window.rs
@@ -123,20 +123,20 @@ pub(super) fn main_handler(key_event: KeyEvent, app: &mut App) {
 }
 
 fn handle_counter_switch(app: &mut App, increment: bool) {
-    if let Some(selected) = app.table.state.selected() {
-        if let Some(element) = app.database.mut_element(selected) {
-            if element.type_ == OTPType::Hotp {
-                // safe to unwrap because the element type is HOTP
-                let counter = element.counter.unwrap();
-                element.counter = if increment {
-                    Some(counter.checked_add(1).unwrap_or(u64::MAX))
-                } else {
-                    Some(counter.saturating_sub(1))
-                };
-                app.database.mark_modified();
-                app.tick(true);
-            }
-        }
+    if let Some(selected) = app.table.state.selected()
+        && let Some(element) = app.database.mut_element(selected)
+        && element.type_ == OTPType::Hotp
+    {
+        // safe to unwrap because the element type is HOTP
+        let counter = element.counter.unwrap();
+        element.counter = if increment {
+            #[allow(clippy::manual_saturating_arithmetic)]
+            Some(counter.checked_add(1).unwrap_or(u64::MAX))
+        } else {
+            Some(counter.saturating_sub(1))
+        };
+        app.database.mark_modified();
+        app.tick(true);
     }
 }
 

--- a/src/interface/handlers/main_window.rs
+++ b/src/interface/handlers/main_window.rs
@@ -130,8 +130,7 @@ fn handle_counter_switch(app: &mut App, increment: bool) {
         // safe to unwrap because the element type is HOTP
         let counter = element.counter.unwrap();
         element.counter = if increment {
-            #[allow(clippy::manual_saturating_arithmetic)]
-            Some(counter.checked_add(1).unwrap_or(u64::MAX))
+            Some(counter.saturating_add(1))
         } else {
             Some(counter.saturating_sub(1))
         };

--- a/src/interface/row.rs
+++ b/src/interface/row.rs
@@ -21,7 +21,7 @@ impl Row {
             + 1) as u16
     }
 
-    pub fn cells(&self) -> Vec<Cell> {
+    pub fn cells(&self) -> Vec<Cell<'_>> {
         self.values
             .iter()
             .map(|c| {

--- a/src/path.rs
+++ b/src/path.rs
@@ -38,14 +38,13 @@ fn get_default_db_path() -> PathBuf {
     data_dir()
         .map(|p| p.join(XDG_PATH))
         .inspect(|xdg| {
-            if !xdg.exists() {
-                if let Some(home) = &home_path {
-                    if home.exists() {
-                        fs::create_dir_all(xdg.parent().unwrap()).expect("Failed to create dir");
-                        fs::copy(home, xdg.as_path())
-                            .expect("Failed on copy from legacy dir to XDG_DATA_HOME");
-                    }
-                }
+            if !xdg.exists()
+                && let Some(home) = &home_path
+                && home.exists()
+            {
+                fs::create_dir_all(xdg.parent().unwrap()).expect("Failed to create dir");
+                fs::copy(home, xdg.as_path())
+                    .expect("Failed on copy from legacy dir to XDG_DATA_HOME");
             }
         })
         .or(home_path)


### PR DESCRIPTION
```
warning: struct `AegisHeader` is never constructed
  --> src\importers\aegis.rs:13:8
   |
13 | struct AegisHeader {
   |        ^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: hiding a lifetime that's elided elsewhere is confusing
  --> src\interface\row.rs:24:18
   |
24 |     pub fn cells(&self) -> Vec<Cell> {
   |                  ^^^^^         ---- the same lifetime is hidden here
   |                  |
   |                  the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
24 |     pub fn cells(&self) -> Vec<Cell<'_>> {
   |                                    ++++

warning: `cotp` (bin "cotp") generated 2 warnings
```
```
❯ rustc -V
rustc 1.91.0-nightly (69b76df90 2025-08-23)
```